### PR TITLE
Fix for inputs 0 and 1

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -80,7 +80,7 @@ pub fn fmt(tree: &[usize]) -> String {
   flat_tree::full_roots(last_block, &mut _roots);
 
   let blank = format!("{:width$}", ' ', width = width);
-  let mut matrix = vec![vec![blank.to_string(); max]; list.len()];
+  let mut matrix = vec![vec![blank.to_string(); max + 1]; list.len()];
 
   for i in 0..list.len() {
     if !list[i] {
@@ -100,11 +100,33 @@ pub fn fmt(tree: &[usize]) -> String {
 
   let mut flat_tree_str = String::from("");
   for arr in matrix {
-    let partial = arr.join("") + "\n";
+    let partial = arr.join("").trim_right().to_string() + "\n";
     flat_tree_str.push_str(partial.as_str());
   }
 
   flat_tree_str
+}
+
+
+#[test]
+fn fmt_works_0() {
+  let tree = vec!(0);
+  let result = fmt(&tree);
+  assert_eq!(result, " 0\n");
+}
+
+#[test]
+fn fmt_works_1() {
+  let tree = vec!(1);
+  let result = fmt(&tree);
+  assert_eq!(result, "\n   1\n");
+}
+
+#[test]
+fn fmt_works_0_1_2() {
+  let tree = vec!(0, 1, 2);
+  let result = fmt(&tree);
+  assert_eq!(result, " 0─┐\n   1\n 2─┘\n");
 }
 
 fn add_path(


### PR DESCRIPTION
This is a bug fix.

## Checklist
- [x] tests pass *
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added

* I had to disable clippy

## Context
When passing 0 or 1 to the binary, it was panic-ing due to passing index out of bounds:
```
$ RUST_BACKTRACE=1 cargo run 1
    Finished dev [unoptimized + debuginfo] target(s) in 0.05s                                                                                                                                                                                                          
     Running `target/debug/print-flat-tree 1`
[false, false]
thread 'main' panicked at 'index out of bounds: the len is 1 but the index is 1', /checkout/src/libcore/slice/mod.rs:2091:14
stack backtrace:
   0: std::sys::unix::backtrace::tracing::imp::unwind_backtrace
             at libstd/sys/unix/backtrace/tracing/gcc_s.rs:49
   1: std::sys_common::backtrace::print
             at libstd/sys_common/backtrace.rs:71
             at libstd/sys_common/backtrace.rs:59
   2: std::panicking::default_hook::{{closure}}
             at libstd/panicking.rs:211
   3: std::panicking::default_hook
             at libstd/panicking.rs:227
   4: std::panicking::rust_panic_with_hook
             at libstd/panicking.rs:475
   5: std::panicking::continue_panic_fmt
             at libstd/panicking.rs:390
   6: rust_begin_unwind
             at libstd/panicking.rs:325
   7: core::panicking::panic_fmt
             at libcore/panicking.rs:77
   8: core::panicking::panic_bounds_check
             at libcore/panicking.rs:59
   9: <usize as core::slice::SliceIndex<[T]>>::index_mut
             at /checkout/src/libcore/slice/mod.rs:2091
  10: core::slice::<impl core::ops::index::IndexMut<I> for [T]>::index_mut
             at /checkout/src/libcore/slice/mod.rs:1964
  11: <alloc::vec::Vec<T> as core::ops::index::IndexMut<I>>::index_mut
             at /checkout/src/liballoc/vec.rs:1729
  12: print_flat_tree::fmt
             at src/lib.rs:91
  13: print_flat_tree::main
             at src/main.rs:22
  14: std::rt::lang_start::{{closure}}
             at /checkout/src/libstd/rt.rs:74
  15: std::panicking::try::do_call
             at libstd/rt.rs:59
             at libstd/panicking.rs:310
  16: __rust_maybe_catch_panic
             at libpanic_unwind/lib.rs:106
  17: std::rt::lang_start_internal
             at libstd/panicking.rs:289
             at libstd/panic.rs:392
             at libstd/rt.rs:58
  18: std::rt::lang_start
             at /checkout/src/libstd/rt.rs:74
  19: main
  20: __libc_start_main
  21: _start

```

## Semver Changes
bugfix change = PATCH increment