### PR TITLE
Keep up with modern times in clippy invocation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,5 +9,5 @@ script: |
   cargo fmt -- --check &&
   cargo build --verbose &&
   cargo test  --verbose &&
-  cargo clippy -- -D clippy
+  cargo clippy -- -D clippy::all
 cache: cargo

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -103,24 +103,23 @@ pub fn fmt(tree: &[usize]) -> String {
   flat_tree_str
 }
 
-
 #[test]
 fn fmt_works_0() {
-  let tree = vec!(0);
+  let tree = vec![0];
   let result = fmt(&tree);
   assert_eq!(result, " 0\n");
 }
 
 #[test]
 fn fmt_works_1() {
-  let tree = vec!(1);
+  let tree = vec![1];
   let result = fmt(&tree);
   assert_eq!(result, "\n   1\n");
 }
 
 #[test]
 fn fmt_works_0_1_2() {
-  let tree = vec!(0, 1, 2);
+  let tree = vec![0, 1, 2];
   let result = fmt(&tree);
   assert_eq!(result, " 0─┐\n   1\n 2─┘\n");
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,7 +1,6 @@
 #![deny(warnings)]
 
 extern crate print_flat_tree as lib;
-#[macro_use]
 extern crate structopt;
 
 use structopt::StructOpt;


### PR DESCRIPTION
This is a 🐛 bug fix.

Fixes the following warning:
`warning: lint name `clippy` is deprecated and does not have an effect anymore. Use: clippy::all`

## Checklist

- [x] tests pass
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added

## Semver Changes
None